### PR TITLE
MaximumRange to determine if device is near or not

### DIFF
--- a/Plugin.Sensors.Android/ProximityImpl.cs
+++ b/Plugin.Sensors.Android/ProximityImpl.cs
@@ -13,7 +13,12 @@ namespace Plugin.Sensors
 
         protected override bool ToReading(SensorEvent e)
         {
-            return true;
+            if (e.Values[0] < e.Sensor.MaximumRange)
+             // Detected something nearby
+                return true;
+            else
+             // Nothing is nearby
+                return false;
         }
     }
 }


### PR DESCRIPTION
Instead of returning always true. which has meaning probably if value changed, we can return actual value if it is near or far. As Google indicates in their docs, we can determine it by comparing with values[0] with MaximumRange. 

Sensor.TYPE_PROXIMITY:
values[0]: Proximity sensor distance measured in centimeters
Note: Some proximity sensors only support a binary near or far measurement. In this case, the sensor should report its maximum range value in the far state and a lesser value in the near state.